### PR TITLE
[script] add one-click download and build script for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ We provide prebuilt binary
 [tarballs](https://github.com/vivoblueos/toolchain/releases) for BlueOS
 development.
 
-# build_mac.sh
-We provide the build_mac.sh script for one-click download and build of the toolchain. Usage:
+# Build on macOS
+We have offered a script `build_for_mac.sh` to download and build the toolchain at one-click. Usage:
 ```bash
 mkdir -p <your_dev_path>/blueos_dev
 cd <your_dev_path>/blueos_dev
-./build_mac.sh --sysroot ../blueos_sysroot
+./build_for_mac.sh --sysroot ../blueos_sysroot
 # add export to your .bashrc
 ./build/ci/run_ci.py
 ```

--- a/build_for_mac.sh
+++ b/build_for_mac.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 # Default values
 SYSROOT_PATH=""
 SHOW_HELP=false


### PR DESCRIPTION
We provide the build_mac.sh script for one-click download and build of the toolchain. Usage:
```bash
mkdir -p <your_dev_path>/blueos_dev
cd <your_dev_path>/blueos_dev
./build_mac.sh --sysroot ../blueos_sysroot
# add export to your .bashrc
./build/ci/run_ci.py
```