### PR TITLE
Install cargo and miri

### DIFF
--- a/.github/workflows/build_and_release_rust.yml
+++ b/.github/workflows/build_and_release_rust.yml
@@ -89,6 +89,8 @@ jobs:
           ./x.py install -i --stage 0 rust-analyzer
           ./x.py install -i --stage 0 clippy
           ./x.py install -i --stage 0 llvm-tools
+          ./x.py install -i --stage 0 cargo
+          ./x.py install -i --stage 0 miri
 
       - name: Create tarball
         run: |


### PR DESCRIPTION
We need cargo as prerequisite of gnrt; need miri to detect UB and race condition.