### PR TITLE
feat: Add miri sysroot

### DIFF
--- a/.github/workflows/build_and_release_rust.yml
+++ b/.github/workflows/build_and_release_rust.yml
@@ -95,6 +95,7 @@ jobs:
           ./x.py install -i --stage 0 llvm-tools
           ./x.py install -i --stage 0 cargo
           ./x.py install -i --stage 0 miri
+          MIRI_LIB_SRC=library MIRI_SYSROOT=${DESTDIR}/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/miri-sysroot cargo miri setup 
 
       - name: Create tarball
         run: |


### PR DESCRIPTION
rollinggulf1999 action test, single target(latest)

fix: get release url changed to fork repo(no permission to upload to upstream repo)

full version, single target(latest) has no influence on action total time

prepare to merge into vivoblueos/toolchain, change release page url back to vivoblueos

add other target rust toolchain