### PR TITLE
build: upgrade Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/build_and_release_rust.yml
+++ b/.github/workflows/build_and_release_rust.yml
@@ -36,20 +36,6 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Checkout libc
-        uses: actions/checkout@v4
-        with:
-          repository: vivoblueos/libc
-          ref: blueos-dev
-          path: libc
-
-      - name: Checkout cc-rs
-        uses: actions/checkout@v4
-        with:
-          repository: vivoblueos/cc-rs
-          ref: blueos-dev
-          path: cc-rs
-
       - name: Checkout rust
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_and_release_rust.yml
+++ b/.github/workflows/build_and_release_rust.yml
@@ -91,12 +91,12 @@ jobs:
           ./x.py install -i --stage 1 library/std --target riscv64-vivo-blueos
           ./x.py install -i --stage 1 library/std --target riscv32-vivo-blueos
           ./x.py install -i --stage 1 library/std --target riscv32imc-vivo-blueos
-          ./x.py install -i --stage 0 rustfmt
-          ./x.py install -i --stage 0 rust-analyzer
-          ./x.py install -i --stage 0 clippy
-          ./x.py install -i --stage 0 llvm-tools
-          ./x.py install -i --stage 0 cargo
-          ./x.py install -i --stage 0 miri
+          ./x.py install -i --stage 1 rustfmt
+          ./x.py install -i --stage 1 rust-analyzer
+          ./x.py install -i --stage 1 clippy
+          ./x.py install -i --stage 1 llvm-tools
+          ./x.py install -i --stage 1 cargo
+          ./x.py install -i --stage 1 miri
           PATH=${DESTDIR}/usr/local/bin:$PATH MIRI_LIB_SRC=library MIRI_SYSROOT=${DESTDIR}/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/miri-sysroot cargo miri setup
           
       - name: Create tarball

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,10 @@ RUN git clone --depth=1 --single-branch -b blueos-dev https://github.com/vivoblu
     ./x.py install -i --stage 1 library/std --target riscv64-vivo-blueos && \
     ./x.py install -i --stage 1 library/std --target riscv32-vivo-blueos && \
     ./x.py install -i --stage 1 library/std --target riscv32imc-vivo-blueos && \
-    ./x.py install -i --stage 0 rustfmt && \
-    ./x.py install -i --stage 0 rust-analyzer && \
-    ./x.py install -i --stage 0 clippy && \
-    ./x.py install -i --stage 0 llvm-tools
+    ./x.py install -i --stage 1 rustfmt && \
+    ./x.py install -i --stage 1 rust-analyzer && \
+    ./x.py install -i --stage 1 clippy && \
+    ./x.py install -i --stage 1 llvm-tools
 RUN cargo install bindgen-cli@0.72.1 cbindgen@0.29.0
 ENV PATH="/blueos-dev/sysroot/usr/local/bin:${PATH}"
 # Install esp32 QEMU.

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ RUN curl -L -o repo https://storage.googleapis.com/git-repo-downloads/repo && ch
 # Build Rust toolchain.
 ENV DESTDIR=/blueos-dev/sysroot
 RUN git clone --depth=1 --single-branch -b blueos-dev https://github.com/vivoblueos/rust.git && \
-    git clone --depth=1 --single-branch -b blueos-dev https://github.com/vivoblueos/cc-rs.git && \
-    git clone --depth=1 --single-branch -b blueos-dev https://github.com/vivoblueos/libc.git && \
     cd rust && cp config.blueos.toml config.toml && \
     ./x.py install -i --stage 1 compiler/rustc && \
     ./x.py install -i --stage 1 library/std --target x86_64-unknown-linux-gnu && \

--- a/build_for_mac.sh
+++ b/build_for_mac.sh
@@ -140,12 +140,12 @@ cp config.blueos.toml config.toml
 ./x.py install -i --stage 1 library/std --target riscv64-vivo-blueos && \
 ./x.py install -i --stage 1 library/std --target riscv32-vivo-blueos && \
 ./x.py install -i --stage 1 library/std --target riscv32imc-vivo-blueos && \
-./x.py install -i --stage 0 rustfmt && \
-./x.py install -i --stage 0 rust-analyzer && \
-./x.py install -i --stage 0 clippy && \
-./x.py install -i --stage 0 llvm-tools && \
-./x.py install -i --stage 0 cargo #&& \
-./x.py install -i --stage 0 miri
+./x.py install -i --stage 1 rustfmt && \
+./x.py install -i --stage 1 rust-analyzer && \
+./x.py install -i --stage 1 clippy && \
+./x.py install -i --stage 1 llvm-tools && \
+./x.py install -i --stage 1 cargo #&& \
+./x.py install -i --stage 1 miri
 PATH=${SYSROOT_PATH}/usr/local/bin:$PATH MIRI_LIB_SRC=library MIRI_SYSROOT=${SYSROOT_PATH}/usr/local/lib/rustlib/aarch64-apple-darwin/miri-sysroot cargo miri setup
 
 # export PATH

--- a/build_for_mac.sh
+++ b/build_for_mac.sh
@@ -128,8 +128,6 @@ export DESTDIR=$SYSROOT_PATH
 mkdir -p $SYSROOT_PATH/src
 cd $SYSROOT_PATH/src
 git clone git@github.com:vivoblueos/rust.git
-git clone git@github.com:vivoblueos/cc-rs.git
-git clone git@github.com:vivoblueos/libc.git
 cd rust
 cp config.blueos.toml config.toml
 ./x.py install -i --stage 1 compiler/rustc && \


### PR DESCRIPTION
# Upgrade Rust toolchain to 1.96.0

## What this PR does

- **Build host tools at stage 1** — install rustfmt, rust-analyzer, clippy,
  llvm-tools, cargo, and miri at `--stage 1` instead of `--stage 0` to match
  the 1.96 toolchain build requirements.
- **Drop explicit libc / cc-rs clones** — libc and cc-rs are now pulled via
  git patches (`[patch.crates-io]`) in the rust repo, so the separate
  `git clone` / `actions/checkout` steps for libc and cc-rs in the build
  scripts are no longer needed.

Applied to `Dockerfile`, `build_for_mac.sh`, and
`.github/workflows/build_and_release_rust.yml`.
